### PR TITLE
Fixes for device remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ all: clean build_android build_ios
 clean:
 	rm -rf build
 
+# to reduce binary file size:
+# (not used) -s omit symbol table and debug info
+# -w omit DWARF symbol table
+# see https://go.dev/doc/gdb
+
 build_android:
 	# *important* gradle does not handle symbolic links consistently
 	# the build dir swap is non-atomic
@@ -15,8 +20,8 @@ build_android:
 		-target android/arm64,android/arm,android/amd64 -androidapi 24 \
 		-javapkg com.bringyour \
 		-trimpath \
-		-gcflags "-dwarf=true" \
-		-ldflags "-X client.Version=$$WARP_VERSION -compressdwarf=false -B gobuildid" \
+		-gcflags "-dwarf=false" \
+		-ldflags "-w -X client.Version=$$WARP_VERSION -compressdwarf=false -B gobuildid" \
 		-o "build/$$BUILD_DIR/URnetworkSdk.aar" \
 		github.com/urnetwork/sdk; \
 	if [[ -e "build/android" ]]; then mv build/android build/android.old.`date +%s`; fi; \
@@ -49,8 +54,8 @@ build_ios:
 		-target ios/arm64,iossimulator/arm64 -iosversion 16.0 \
 		-bundleid com.bringyour \
 		-trimpath \
-		-gcflags "-dwarf=true" \
-		-ldflags "-X client.Version=$$WARP_VERSION -compressdwarf=false -B gobuildid" \
+		-gcflags "-dwarf=false" \
+		-ldflags "-s -w -X client.Version=$$WARP_VERSION -compressdwarf=false -B gobuildid" \
 		-o "build/$$BUILD_DIR/URnetworkSdk.xcframework" \
 		github.com/urnetwork/sdk; \
 	if [[ -e "build/ios" ]]; then mv build/ios build/ios.old.`date +%s`; fi; \

--- a/device.go
+++ b/device.go
@@ -49,6 +49,7 @@ type ConnectLocationChangeListener interface {
 	ConnectLocationChanged(location *ConnectLocation)
 }
 
+// FIXME rename to ProvideSecretKeysChangeListener
 type ProvideSecretKeysListener interface {
 	ProvideSecretKeysChanged(provideSecretKeyList *ProvideSecretKeyList)
 }

--- a/sdk.go
+++ b/sdk.go
@@ -315,6 +315,17 @@ func (self *ConnectLocation) ToCountry() *ConnectLocation {
 	}
 }
 
+func (self *ConnectLocation) Equals(b *ConnectLocation) bool {
+	if b == nil {
+		return false
+	}
+	if self.ConnectLocationId == nil {
+		return b.ConnectLocationId == nil
+	}
+	return self.ConnectLocationId.Cmp(b.ConnectLocationId) == 0
+}
+
+
 // merged location and location group
 type ConnectLocationId struct {
 	// if set, the location is a direct connection to another device
@@ -335,6 +346,9 @@ func (self *ConnectLocationId) IsDevice() bool {
 func (self *ConnectLocationId) Cmp(b *ConnectLocationId) int {
 	// - direct
 	// - group
+	if b == nil {
+		return -1
+	}
 	if self.ClientId != nil && b.ClientId != nil {
 		if c := self.ClientId.Cmp(b.ClientId); c != 0 {
 			return c

--- a/view_controller.go
+++ b/view_controller.go
@@ -40,7 +40,6 @@ type ViewControllerManager interface {
 	CloseViewController(vc ViewController) 
 
 	Close()
-
 }
 
 
@@ -156,3 +155,4 @@ func (self *viewControllerManager) Close() {
 	}
 	clear(self.openedViewControllers)
 }
+


### PR DESCRIPTION
Connecting the remote to local when the sync is completed immediately had issues. This is the case of a new app connecting to an existing network extension on iOS. Added tests and fixes.

Also reduce the binary size by removing DWARF symbols. This helps add more memory for the iOS network extension (I think).
