### PR TITLE
ip security fixes

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -36,7 +36,7 @@ require (
 	golang.org/x/mobile v0.0.0-20250408133729-978277e7eaf7 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/tools v0.32.0 // indirect
 	honnef.co/go/tools v0.3.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/device_local.go
+++ b/device_local.go
@@ -298,6 +298,8 @@ func newDeviceLocalWithOverrides(
 
 	if enableRpc {
 		deviceLocal.deviceLocalRpcManager = newDeviceLocalRpcManagerWithDefaults(ctx, deviceLocal)
+	} else {
+		newSecurityPolicyMonitor(ctx, deviceLocal)
 	}
 
 	return deviceLocal, nil
@@ -978,7 +980,7 @@ func (self *DeviceLocal) SetDestination(location *ConnectLocation, specs *Provid
 				self.ctx,
 				generator,
 				remoteReceive,
-				protocol.ProvideMode_Network,
+				protocol.ProvideMode_Public,
 			)
 			multi.AddContractStatusCallback(self.updateContractStatus)
 			self.remoteUserNatClient = multi

--- a/device_rpc.go
+++ b/device_rpc.go
@@ -1719,6 +1719,7 @@ func (self *DeviceRemote) egressSecurityPolicyStats(reset bool) connect.Security
 	var out connect.SecurityPolicyStats
 	if success {
 		out = stats
+		self.state.ResetEgressSecurityPolicyStats.Unset()
 	} else if self.state.ResetEgressSecurityPolicyStats.IsSet {
 		out = connect.SecurityPolicyStats{}
 	} else {
@@ -1784,6 +1785,7 @@ func (self *DeviceRemote) ingressSecurityPolicyStats(reset bool) connect.Securit
 	var out connect.SecurityPolicyStats
 	if success {
 		out = stats
+		self.state.ResetIngressSecurityPolicyStats.Unset()
 	} else if self.state.ResetIngressSecurityPolicyStats.IsSet {
 		out = connect.SecurityPolicyStats{}
 	} else {


### PR DESCRIPTION
Set Egress traffic default public. Add a security log monitor to local devices (Android).

Depends on https://github.com/urnetwork/connect/pull/99