### PR TITLE
allow re-prompting intro funnel after some time

### DIFF
--- a/device.go
+++ b/device.go
@@ -189,6 +189,10 @@ type Device interface {
 
 	SetCanShowRatingDialog(canShowRatingDialog bool)
 
+	GetCanPromptIntroFunnel() bool
+
+	SetCanPromptIntroFunnel(canPrompt bool)
+
 	GetAllowForeground() bool
 
 	SetAllowForeground(allowForeground bool)

--- a/device_local.go
+++ b/device_local.go
@@ -32,6 +32,7 @@ func (self *emptyWindowMonitor) Events() (*connect.WindowExpandEvent, map[connec
 
 const defaultRouteLocal = true
 const defaultCanShowRatingDialog = true
+const defaultCanShowIntroFunnel = true
 
 const defaultProvideControlMode = ProvideControlModeManual
 const defaultProvideNetworkMode = ProvideNetworkModeWiFi
@@ -113,10 +114,11 @@ type DeviceLocal struct {
 	remoteUserNatProviderLocalUserNat *connect.LocalUserNat
 	remoteUserNatProvider             *connect.RemoteUserNatProvider
 
-	routeLocal          bool
-	canShowRatingDialog bool
-	canRefer            bool
-	allowForeground     bool
+	routeLocal           bool
+	canShowRatingDialog  bool
+	canPromptIntroFunnel bool
+	canRefer             bool
+	allowForeground      bool
 
 	provideMode              ProvideMode
 	provideControlMode       ProvideControlMode // auto, always, never
@@ -280,6 +282,7 @@ func newDeviceLocalWithOverrides(
 		remoteUserNatProvider:             nil,
 		routeLocal:                        defaultRouteLocal,
 		canShowRatingDialog:               defaultCanShowRatingDialog,
+		canPromptIntroFunnel:              defaultCanShowIntroFunnel,
 		canRefer:                          defaultCanRefer,
 		allowForeground:                   defaultAllowForeground,
 		provideMode:                       ProvideModeNone,
@@ -471,6 +474,21 @@ func (self *DeviceLocal) SetCanShowRatingDialog(canShowRatingDialog bool) {
 	self.stateLock.Lock()
 	defer self.stateLock.Unlock()
 	self.canShowRatingDialog = canShowRatingDialog
+}
+
+/**
+ * Prompt Intro tunnel
+ */
+func (self *DeviceLocal) GetCanPromptIntroFunnel() bool {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+	return self.canPromptIntroFunnel
+}
+
+func (self *DeviceLocal) SetCanPromptIntroFunnel(canPrompt bool) {
+	self.stateLock.Lock()
+	defer self.stateLock.Unlock()
+	self.canPromptIntroFunnel = canPrompt
 }
 
 /**

--- a/local_state.go
+++ b/local_state.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"time"
 
 	// "io"
 	"encoding/json"
@@ -308,6 +309,36 @@ func (self *LocalState) GetCanShowRatingDialog() bool {
 		var canShowRatingDialog bool
 		if err := json.Unmarshal(canShowRatingDialogBytes, &canShowRatingDialog); err == nil {
 			return canShowRatingDialog
+		}
+	}
+	return true
+}
+
+func (self *LocalState) SetIntroFunnelLastPrompted() error {
+
+	now := time.Now()
+
+	path := filepath.Join(self.localStorageDir, ".can_prompt_intro_funnel")
+	lastPromptedBytes, err := json.Marshal(now)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, lastPromptedBytes, LocalStorageFilePermissions)
+}
+
+func (self *LocalState) GetCanPromptIntroFunnel() bool {
+	path := filepath.Join(self.localStorageDir, ".can_prompt_intro_funnel")
+
+	if intoFunnelTimeLastPromptedBytes, err := os.ReadFile(path); err == nil {
+		var intoFunnelTimeLastPrompted time.Time
+		if err := json.Unmarshal(intoFunnelTimeLastPromptedBytes, &intoFunnelTimeLastPrompted); err == nil {
+
+			now := time.Now().UTC()
+
+			timePassed := now.Sub(intoFunnelTimeLastPrompted)
+
+			return timePassed.Hours() > 24*5
+
 		}
 	}
 	return true


### PR DESCRIPTION
persist the last time the intro funnel was launched unprompted to local storage.
use this to check if we allow unprompted launching of intro funnel on launch.